### PR TITLE
ddfields type workaround with variable

### DIFF
--- a/src/zcl_otm_table_maintenance.clas.abap
+++ b/src/zcl_otm_table_maintenance.clas.abap
@@ -132,8 +132,6 @@ CLASS zcl_otm_table_maintenance IMPLEMENTATION.
 
 
   METHOD list_key_fields.
-
-    CONSTANTS workaround TYPE string VALUE 'DDFIELDS'.
     DATA obj TYPE REF TO object.
     DATA lv_tabname TYPE c LENGTH 16.
     DATA lr_ddfields TYPE REF TO data.
@@ -157,6 +155,7 @@ CLASS zcl_otm_table_maintenance IMPLEMENTATION.
           RECEIVING
             rt_names = names.
       CATCH cx_sy_dyn_call_illegal_class.
+        DATA(workaround) = 'DDFIELDS'.
         CREATE DATA lr_ddfields TYPE (workaround).
         ASSIGN lr_ddfields->* TO <ddfields>.
         ASSERT sy-subrc = 0.


### PR DESCRIPTION
Hey, Lars,

I imagine the `workaround` constant was to avoid the fact that `DDFIELDS` type cannot be used in Steampunk, and so this would avoid syntax errors.

However, apparently, the compiler is smart enough to notice that this is a constant, so it still finds this error:

![image](https://user-images.githubusercontent.com/47610738/151017440-fa875a96-c5fa-472e-b7eb-4e3507b9e14c.png)

If we change it into a variable, luckily, we manage to trick it, and it's all good, activation is possible:

![image](https://user-images.githubusercontent.com/47610738/151017658-96cb4abb-a3f1-4b00-9d8c-50469b6c4f62.png)